### PR TITLE
if simulationParams = {'rec_imem': True}, apply LFPykit probe maps to recorded transmembrane currents

### DIFF
--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_default.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_default.py
@@ -923,7 +923,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_exc.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_exc.py
@@ -927,7 +927,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_inh.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_inh.py
@@ -927,7 +927,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_input.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_ac_input.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_exc.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_exc.py
@@ -927,7 +927,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_inh.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_inh.py
@@ -927,7 +927,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_input.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_regular_input.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan_exc.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan_exc.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan_inh.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_modified_spontan_inh.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_spikegen.py
+++ b/examples/Hagen_et_al_2016_cercor/cellsim16popsParams_spikegen.py
@@ -925,7 +925,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/example_microcircuit_params.py
+++ b/examples/example_microcircuit_params.py
@@ -904,7 +904,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/examples/example_microcircuit_params_lognormalweights.py
+++ b/examples/example_microcircuit_params_lognormalweights.py
@@ -911,7 +911,7 @@ class multicompartment_params(point_neuron_network_params):
 
 
         # additional simulation kwargs, see LFPy.Cell.simulate() docstring
-        self.simulationParams = {}
+        self.simulationParams = {'rec_imem': True}
 
 
         # a dict setting the number of cells N_y and geometry

--- a/hybridLFPy/population.py
+++ b/hybridLFPy/population.py
@@ -330,8 +330,21 @@ class PopulationSuper(object):
             for probe in self.probes:
                 probe.cell = cell
 
+            if 'rec_imem' in self.simulationParams.keys():
+                try:
+                    assert self.simulationParams['rec_imem']
+                    cell.simulate(**self.simulationParams)
+                    for probe in self.probes:
+                        M = probe.get_transformation_matrix()
+                        probe.data = M @ cell.imem
+                    del cell.imem
+                except AssertionError:
+                    cell.simulate(probes=self.probes, **self.simulationParams)
+            else:
+                cell.simulate(probes=self.probes, **self.simulationParams)
+
             # make predictions
-            cell.simulate(probes=self.probes, **self.simulationParams)
+            # cell.simulate(probes=self.probes, **self.simulationParams)
 
             # downsample probe.data attribute and unset cell
             for probe in self.probes:
@@ -1273,8 +1286,21 @@ class Population(PopulationSuper):
             for probe in self.probes:
                 probe.cell = cell
 
+            if 'rec_imem' in self.simulationParams.keys():
+                try:
+                    assert self.simulationParams['rec_imem']
+                    cell.simulate(**self.simulationParams)
+                    for probe in self.probes:
+                        M = probe.get_transformation_matrix()
+                        probe.data = M @ cell.imem
+                    del cell.imem
+                except AssertionError:
+                    cell.simulate(probes=self.probes, **self.simulationParams)
+            else:
+                cell.simulate(probes=self.probes, **self.simulationParams)
+
             # make predictions
-            cell.simulate(probes=self.probes, **self.simulationParams)
+            # cell.simulate(probes=self.probes, **self.simulationParams)
 
             # downsample probe.data attribute and unset cell
             for probe in self.probes:


### PR DESCRIPTION
Reduces L23E per-cell simulation speeds by a factor (27/48~=) 0.56 in Hagen2016 example files. 
Closes #33 