### PR TITLE
Reduce memory footprint

### DIFF
--- a/examples/brunel_alpha_nest_topo_exp.py
+++ b/examples/brunel_alpha_nest_topo_exp.py
@@ -369,10 +369,10 @@ def run_model():
 
         eevents = np.loadtxt(nest.GetStatus(espikes, 'filenames')[0][0],
                              skiprows=3,
-                             dtype=[('senders', np.int), ('times', np.float)])
+                             dtype=[('senders', int), ('times', float)])
         ievents = np.loadtxt(nest.GetStatus(ispikes, 'filenames')[0][0],
                              skiprows=3,
-                             dtype=[('senders', np.int), ('times', np.float)])
+                             dtype=[('senders', int), ('times', float)])
         X = []
         T = []
         for i, j in enumerate(nodes_ex):


### PR DESCRIPTION
Closes #75 

This PR avoids the intermediate storage of single-cell probe output by immediately summing contributions computed on each RANK.