### PR TITLE
Reduce memory footprint

### DIFF
--- a/examples/brunel_alpha_nest_topo_exp.py
+++ b/examples/brunel_alpha_nest_topo_exp.py
@@ -369,10 +369,10 @@ def run_model():
 
         eevents = np.loadtxt(nest.GetStatus(espikes, 'filenames')[0][0],
                              skiprows=3,
-                             dtype=[('senders', np.int), ('times', np.float)])
+                             dtype=[('senders', int), ('times', float)])
         ievents = np.loadtxt(nest.GetStatus(ispikes, 'filenames')[0][0],
                              skiprows=3,
-                             dtype=[('senders', np.int), ('times', np.float)])
+                             dtype=[('senders', int), ('times', float)])
         X = []
         T = []
         for i, j in enumerate(nodes_ex):

--- a/hybridLFPy/population.py
+++ b/hybridLFPy/population.py
@@ -596,11 +596,11 @@ class PopulationSuper(object):
         if self.RANK_CELLINDICES.size > 0:
             data = self.output[measure]
         else:
-            data = np.zeros(shape, dtype=np.float32)
+            data = np.zeros(shape, dtype=np.float64)
 
         # container for full LFP on RANK 0
         if RANK == 0:
-            DATA = np.zeros_like(data, dtype=np.float32)
+            DATA = np.zeros_like(data, dtype=np.float64)
         else:
             DATA = None
 
@@ -1290,8 +1290,7 @@ class Population(PopulationSuper):
             # downsample probe.data attribute and unset cell
             for probe in self.probes:
                 probe.data = ss.decimate(probe.data,
-                                         q=self.decimatefrac
-                                         ).astype(np.float32)
+                                         q=self.decimatefrac)
                 probe.cell = None
 
             # put all necessary cell output in output dict


### PR DESCRIPTION
Closes #75. 
This removes the need to store single-cell probe contributions, reducing memory consumption accordingly.